### PR TITLE
Fix the response for actions without methods

### DIFF
--- a/lib/Catalyst/ActionRole/Methods.pm
+++ b/lib/Catalyst/ActionRole/Methods.pm
@@ -96,7 +96,7 @@ sub _return_options {
     my @allowed = $self->get_allowed_methods($controller, $c, $method_name);
     $c->response->content_type('text/plain');
     $c->response->status(200);
-    $c->response->header( 'Allow' => \@allowed );
+    $c->response->header( 'Allow' => @allowed ? \@allowed : '' );
     $c->response->body(q{});
 }
  
@@ -106,7 +106,7 @@ sub _return_not_implemented {
     my @allowed = $self->get_allowed_methods($controller, $c, $method_name);
     $c->response->content_type('text/plain');
     $c->response->status(405);
-    $c->response->header( 'Allow' => \@allowed );
+    $c->response->header( 'Allow' => @allowed ? \@allowed : '' );
     $c->response->body( "Method "
           . $c->request->method
           . " not implemented for "

--- a/t/basic.t
+++ b/t/basic.t
@@ -32,6 +32,8 @@ use Test::Most;
 
     sub next_action_in_chain :Chained(myaction) PathPart('') Args(0) { }
 
+    sub no_methods_implemented :Chained(/) Does('Methods') PathPart('fail') Args(0) { }
+
   $INC{'MyApp/Controller/Root.pm'} = __FILE__;
   MyApp::Controller::Root->config(namespace=>'');
 
@@ -62,6 +64,12 @@ use HTTP::Request::Common;
 {
   ok my $res = request(PUT '/22');
   is $res->content, '1na22';
+}
+
+{
+  ok my $res = request(GET '/fail');
+  is $res->code, 405;
+  is $res->header( 'Allow' ), '';
 }
 
 done_testing;


### PR DESCRIPTION
The other day I copy-pasted an action and modified it, but every attempt to load it would end with “no response from server” in the browser and the following error on the terminal:

> Caught exception in engine "Response headers MUST be a defined string at local/lib/perl5/Plack/Middleware/Lint.pm line 142."

It was only after a fair amount of head-scratching that I noticed the action I copy-pasted included a `Does('Methods')` attribute. The new action I was creating did not require method-based dispatch, and so I had not defined any methods for it, but I forgot to remove the attribute. So I was left with a `Does('Methods')` action that didn’t support any HTTP methods.

Once I noticed the stray attribute, it was easy to figure out what was going wrong. But I had no help in noticing it: the error I had been getting did nothing to point me in the right direction.

This patch fixes that. With it, the linter does not complain and you get a regular 405 which should make it obvious enough what is wrong. It also conforms [to the HTTP RFC](https://tools.ietf.org/html/rfc7231#section-7.4.1).