### PR TITLE
POD encoding error fix

### DIFF
--- a/lib/Catalyst/ActionRole/Methods.pm
+++ b/lib/Catalyst/ActionRole/Methods.pm
@@ -115,6 +115,12 @@ sub _return_not_implemented {
 
 1;
 
+__END__
+
+=pod
+
+=encoding UTF-8
+
 =head1 NAME
 
 Catalyst::ActionRole::Methods - Dispatch by HTTP Methods


### PR DESCRIPTION
Both CPAN and GitHub are complaining:

> The following errors were encountered while parsing the POD:
> 
> Around line 340:
> > Non-ASCII character seen before =encoding in 'André'. Assuming UTF-8

